### PR TITLE
Fixed collector not working on calc.ts

### DIFF
--- a/src/calc.ts
+++ b/src/calc.ts
@@ -6,7 +6,8 @@ import {
 	EmbedAuthorOptions,
 	EmbedFooterOptions,
 	ColorResolvable,
-	ButtonInteraction
+	ButtonInteraction,
+	ComponentType
 } from 'discord.js';
 import { ExtendedInteraction, ExtendedMessage } from './interfaces';
 
@@ -180,7 +181,7 @@ export async function calculator(
 
 		const collect = msg.createMessageComponentCollector({
 			filter,
-			componentType: 'BUTTON',
+			componentType: ComponentType.Button,
 			time: time
 		});
 


### PR DESCRIPTION
When the component collector was created the type it collects does not exist in djs v14 `componentType: "BUTTON"` we have to use the new ones which use the ComponentType enum included with discord.js. https://discordjs.guide/popular-topics/collectors.html#basic-message-component-collector On testing without this change the collector would not even collect anything.

---
name: Pull Request
about: Improve the package by contributing.
title: 'Pull Request'
labels: 'pr'
assignees: ''
---

# Description

_Overview of the things you changed_
Changed the collector component type to the v14 enum as mentioned in the [discord.js guide](https://discordjs.guide/popular-topics/collectors.html#basic-message-component-collector)

# Screenshots

If applicable, add screenshots to help explain the things changed.

# Issue Related

[Issue Name](provide-link-to-related-issue-if-any)

# Checks

This issue while testing the function on my bot
